### PR TITLE
Slim Down Page Builds Part 1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,14 +6,21 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '*/1 * * * *'
   push:
-    branches: [ main ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    branches:
+      - 'main'
+    paths-ignore:
+      - 'README.md'
+    # Publish semver tags as releases. Allow for '-alpha'
+    # stage releases as well.
+    tags: 
+      - 'v*.*.*'
+      - 'v*.*.*-alpha'
   pull_request:
-    branches: [ main ]
+    branches: 
+      - 'main'
+    paths-ignore:
+      - 'README.md'
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -21,14 +28,9 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -38,7 +40,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -48,16 +50,35 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v2
         with:
           context: .
+          file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Render Action Metadata
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          ./bin/render_action_metadata "docker://ghcr.io/paper-spa/pages:${{ github.ref_name }}" > action.yml
+          git add action.yml
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Add generated action.yml 🤖"
+          if [[ '${{ github.ref_type }}' == 'tag' ]]; then 
+            echo "Pushing tag ${{ github.ref_name }}"
+            git tag -f ${{ github.ref_name }}
+            git push -f origin ${{ github.ref_name }}
+          else
+            echo "Pushing branch ${{ github.ref_name }}"
+            git push origin ${{ github.ref_name }}
+          fi
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,12 @@ jobs:
     env:
       TEST_NAME: simple
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Render Action Metadata
+        run: |
+          ./bin/render_action_metadata Dockerfile > action.yml
 
       - name: Test ${{ env.TEST_NAME }} Project
         uses: ./
@@ -26,21 +31,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save test results
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          git checkout -b "${GIT_BRANCH}-test-${TEST_NAME}"
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ github.workspace }}/test_projects
-          git commit -m "Test results: $(date)" || true
-          git push -fu origin "${GIT_BRANCH}-test-${TEST_NAME}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: ./test_projects/${{ env.TEST_NAME }}
 
   test-readme:
     runs-on: ubuntu-latest
     env:
       TEST_NAME: readme
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Render Action Metadata
+        run: |
+          ./bin/render_action_metadata Dockerfile > action.yml
 
       - name: Test ${{ env.TEST_NAME }} Project
         uses: ./
@@ -50,21 +56,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save test results
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          git checkout -b "${GIT_BRANCH}-test-${TEST_NAME}"
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ github.workspace }}/test_projects
-          git commit -m "Test results: $(date)" || true
-          git push -fu origin "${GIT_BRANCH}-test-${TEST_NAME}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: ./test_projects/${{ env.TEST_NAME }}
 
   test-mojombo:
     runs-on: ubuntu-latest
     env:
       TEST_NAME: mojombo
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Render Action Metadata
+        run: |
+          ./bin/render_action_metadata Dockerfile > action.yml
 
       - name: Test ${{ env.TEST_NAME }} Project
         uses: ./
@@ -74,21 +81,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save test results
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          git checkout -b "${GIT_BRANCH}-test-${TEST_NAME}"
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ github.workspace }}/test_projects
-          git commit -m "Test results: $(date)" || true
-          git push -fu origin "${GIT_BRANCH}-test-${TEST_NAME}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: ./test_projects/${{ env.TEST_NAME }}
 
   test-themes:
     runs-on: ubuntu-latest
     env:
       TEST_NAME: themes
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Render Action Metadata
+        run: |
+          ./bin/render_action_metadata Dockerfile > action.yml
 
       - name: Test ${{ env.TEST_NAME }} Project
         uses: ./
@@ -98,21 +106,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save test results
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          git checkout -b "${GIT_BRANCH}-test-${TEST_NAME}"
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ github.workspace }}/test_projects
-          git commit -m "Test results: $(date)" || true
-          git push -fu origin "${GIT_BRANCH}-test-${TEST_NAME}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: ./test_projects/${{ env.TEST_NAME }}
 
   test-jekyll-include-cache:
     runs-on: ubuntu-latest
     env:
       TEST_NAME: jekyll-include-cache
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Render Action Metadata
+        run: |
+          ./bin/render_action_metadata Dockerfile > action.yml
 
       - name: Test ${{ env.TEST_NAME }} Project
         uses: ./
@@ -122,11 +131,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save test results
-        run: |
-          GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          git checkout -b "${GIT_BRANCH}-test-${TEST_NAME}"
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ github.workspace }}/test_projects
-          git commit -m "Test results: $(date)" || true
-          git push -fu origin "${GIT_BRANCH}-test-${TEST_NAME}"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: ./test_projects/${{ env.TEST_NAME }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,25 @@
-FROM ghcr.io/github/pages-gem:v222
+ARG RUBY_VERSION=2.7.4
+FROM ruby:$RUBY_VERSION-slim
+
+RUN apt-get update \
+  && apt-get install -y \
+    build-essential \
+    git \
+    locales \
+    nodejs
+
+COPY Gemfile Gemfile
+
+RUN NOKOGIRI_USE_SYSTEM_LIBRARIES=true bundle install
+
+RUN \
+  echo "en_US UTF-8" > /etc/locale.gen && \
+  locale-gen en-US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 COPY entrypoint.sh /entrypoint.sh
-
+ 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Manage our dependency on the version of the github-pages gem here.
+gem "github-pages", "= 222"
+
+# Explicitly include this gem here.
+# It is not directly included in the github-pages gem list of dependencies,
+# even though it is included in the original GitHub Pages build infrastructure.
+gem "jekyll-include-cache", "= 0.2.1"

--- a/action.yml.erb
+++ b/action.yml.erb
@@ -1,3 +1,4 @@
+# <%= nonce %>
 name: 'Pages Jekyll'
 description: 'A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages'
 inputs:
@@ -19,5 +20,5 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: '<%= pages_action_url %>'
 

--- a/bin/render_action_metadata
+++ b/bin/render_action_metadata
@@ -1,0 +1,19 @@
+#! /usr/bin/env ruby
+
+# Internal: Generate an action.yml metadata file using the inputs
+#
+# pages_action_url - Docker image URL to be used as the base action image.
+
+require 'erb'
+require 'securerandom'
+
+nonce = SecureRandom.hex
+pages_action_url = ARGV[0]
+
+action_erb_path = File.dirname(__FILE__) + '/../action.yml.erb'
+
+result = File.open(action_erb_path, 'r') do |file|
+  ERB.new(file.read).result(binding)
+end
+
+puts result

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ set -o errexit
 
 SOURCE_DIRECTORY=${GITHUB_WORKSPACE}/$INPUT_SOURCE
 DESTINATION_DIRECTORY=${GITHUB_WORKSPACE}/$INPUT_DESTINATION
-PAGES_GEM_HOME=/src/gh/pages-gem
+PAGES_GEM_HOME=$BUNDLE_APP_CONFIG
 GITHUB_PAGES=$PAGES_GEM_HOME/bin/github-pages
 
 # Set environment variables required by supported plugins


### PR DESCRIPTION
This is an attempt to simplify (in terms of dependencies at least) and slim down the current build process for this action.

Instead of relying on the Docker images defined in the `pages-gem` that were originally built to support unit testing and included files unnecessary to the this action's needs, we instead introduce a purpose-built one here. It includes a `Gemfile` that directly references the `pages-gem` by version and builds that along with an `entrypoint` reference.

In order to reduce this action's run times, we reference the built Docker image via URL in the `action.yml`. This introduced some challenges for the CD process (unless I'm missing something obvious...I hope I am!). To allow for automatically referencing a newly-built version by tag, we leverage a templated version of the action metadata file which gets generated with the intended tagged URL reference at build time. The CD workflow then commits the generated file and if necessary refreshes the release tags.

When (very unscientifically) comparing this action's run times using this infra vs the previous, I was seeing builds just under a minute while previous ones were around 1m 10s. The next phase would be to use Alpine instead of Debian which should hopefully make for a smaller overall image size, but this feels like a step in the right direction.

For all I know, this could all be wrong, but it's the best I've come up with so far. Comments/suggestions welcome!