### PR TITLE
Add minimum doc + license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pages-jekyll
+# Pages-Jekyll
 
 A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages.
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,15 @@
 # pages-jekyll
-A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages
+
+A simple GitHub Action for producing Jekyll build artifacts compatible with GitHub Pages.
+
+# Scope
+
+This is used along with [`actions/deploy-pages`](https://github.com/actions/deploy-pages) as part of the official support for building Pages with Actions (currently in public beta for public repositories).
 
 # Usage
 
-## Build with Pages-gem and deploy to GitHub Pages
+See [action.yml](action.yml)
 
-```yaml
-jobs:
-  build-pages:
-    runs-on: ubuntu-latest
-    name: Build Pages with Jekyll
-    steps:
-      - name: Build page with Jekyll
-        uses: actions/pages-jekyll@v4
-        with:
-          source: ./source_dir
-          destination: ./source_dir/_site
-  deploy-to-pages:
-    runs-on: ubuntu-latest
-    name: Deploy to Pages
-    steps:
-      - name: Upload artifact
-        uses: actions/upload-artifact@main
-        with:
-          name: github-pages
-          path: ./dist
-      - name: Deploy artifact
-        uses: actions/deploy-pages@main
-        with:
-          artifact-name: github-pages
-```
+# License
 
+The scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -21,4 +21,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/paper-spa/pages:main'
-


### PR DESCRIPTION
Add basic structure to the README file.

Drop references to the standard workflow (it is out of date, and I want to wait for the blogpost to be out for officially documenting the "bring your own workflow approach").

Add MIT license too.