### PR TITLE
Allow any tag matching `v*` to trigger workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,9 +14,9 @@ on:
     # Publish semver tags as releases. Allow for '-alpha'
     # and '-beta' stage releases as well.
     tags: 
-      - 'v*.*.*'
       - 'v*.*.*-alpha'
       - 'v*.*.*-beta'
+      - 'v*'
   pull_request:
     branches: 
       - 'main'


### PR DESCRIPTION
Since actions supports semantics such as `v1`/`v2`, thinking we should trigger this workflow on those as well.